### PR TITLE
feat: contextの一部に任意の情報を上書き出来るようパラメータ追加

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -112,4 +112,26 @@ describe('mockContext', () => {
   test('timeout throws error', () => {
     expect(invokeAsync('succeed', 'foo', { ms: 2000, timeout: 1 })).rejects.toThrow('Task timed out after 1.00 seconds')
   })
+
+  test('extended context', () => {
+    const ctx = context(
+      {
+        region: 'eu-west-1',
+        account: '210987654321',
+        functionName: 'test',
+        functionVersion: '1',
+        memoryLimitInMB: '512',
+        alias: 'production',
+      },
+      {
+        foo: 'bar',
+        a: {
+          b: 'c',
+        },
+      },
+    )
+
+    expect(ctx.foo).toEqual('bar')
+    expect(ctx.a).toEqual({ b: 'c' })
+  })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ const lambdaTimeout = (context: MockContext, timeout: number): NodeJS.Timeout =>
   }, timeout * 1000)
 }
 
-const context = (options?: Options): MockContext => {
+const context = <E = Record<string, any>>(options?: Options, overrides?: E): MockContext & E => {
   const id = uuidv1()
   const stream = uuidv4().replace(/-/g, '')
 
@@ -115,7 +115,7 @@ const context = (options?: Options): MockContext => {
     timeout = lambdaTimeout(context, opts.timeout)
   }
 
-  return context
+  return Object.assign(context, overrides)
 }
 
 export default context


### PR DESCRIPTION
middyのcontextをmockする際のコードを減らすための実装